### PR TITLE
fix possible 0xff in uuid will cause Not settable error

### DIFF
--- a/parser/system/parse.go
+++ b/parser/system/parse.go
@@ -30,12 +30,12 @@ func Parse(s *smbios.Structure) (info *Information, err error) {
 // If the value is all FFh, the ID is not currently present in the system,
 // but it can be set. If the value is all 00h, the ID is not present in the system.
 func uuid(data []byte, ver string) string {
-	if bytes.Index(data, []byte{0x00}) != -1 {
+	if bytes.Equal(data, bytes.Repeat([]byte{0x00}, len(data))) {
 		return "Not present"
 	}
 
-	if bytes.Index(data, []byte{0xFF}) != -1 {
-		return "Not settable"
+	if bytes.Equal(data, bytes.Repeat([]byte{0xff}, len(data))) {
+		return "Settable"
 	}
 
 	if ver > "2.6" {


### PR DESCRIPTION
On one of my AWS servers, it doesn't work correctly. I found that there's a '0xff' in the UUID bytes. According to the standard, all 0 or all 0xff means "not present" and "not present but settable" accordingly.

it's a fix to this issue.

![spec](https://user-images.githubusercontent.com/1330008/136653844-6227517a-ec72-4805-b5fa-ddbf2e9cd67f.png)