### PR TITLE
fix panic when system infomation has bad index

### DIFF
--- a/smbios/structure.go
+++ b/smbios/structure.go
@@ -169,6 +169,10 @@ func (s *Structure) GetString(offset int) string {
 		return "Unknown"
 	}
 
+	if len(s.Strings) < int(index) {
+		return "Unknown"
+	}
+
 	return s.Strings[index-1]
 }
 


### PR DESCRIPTION
SMBIOS 信息异常时, dmidecode 命令显示 `<BAD INEX>` , 代码会 panic

---

```
Handle 0x0001, DMI type 1, 27 bytes
System Information
        Manufacturer: Colorful Technology And Development Co.,LTD
        Product Name: CVN B660I GAMING
        Version: Default string
        Serial Number: Default string
        UUID: 03000200-0400-0500-0006-000700080009
        Wake-up Type: Power Switch
        SKU Number: Default string
        Family: <BAD INDEX>
```

---

```
panic: runtime error: index out of range [5] with length 5

goroutine 1 [running]:
github.com/yumaojun03/dmidecode/smbios.(*Structure).GetString(...)
        /root/go/pkg/mod/github.com/yumaojun03/dmidecode@v0.1.4/smbios/structure.go:172
github.com/yumaojun03/dmidecode/parser/system.Parse(0xc000766640, 0xc000766640, 0x1, 0xc00089fa50)
        /root/go/pkg/mod/github.com/yumaojun03/dmidecode@v0.1.4/parser/system/parse.go:21 +0x839
github.com/yumaojun03/dmidecode.(*Decoder).System(0xc0003e4000, 0x0, 0x0, 0xc000749cf0, 0xc00088fb20, 0xc00088fb15)
        /root/go/pkg/mod/github.com/yumaojun03/dmidecode@v0.1.4/decoder.go:107 +0x105
```